### PR TITLE
[codex] fix staging channel state panics

### DIFF
--- a/src/pg_write/operates.rs
+++ b/src/pg_write/operates.rs
@@ -243,7 +243,7 @@ pub async fn daily_statistics(
         COALESCE(c.name, 'ckb') as name, r.capacity as capacity
     FROM {} n
     left join {} c on n.udt_type_script = c.id
-    left join {} r on n.channel_outpoint = r.channel_outpoint
+    join {} r on n.channel_outpoint = r.channel_outpoint
     WHERE bucket < $1::timestamp and bucket >= $2::timestamp
     ORDER BY time_bucket('1 day', bucket), n.channel_outpoint, bucket DESC
     ",

--- a/src/pg_write/operates.rs
+++ b/src/pg_write/operates.rs
@@ -476,6 +476,8 @@ pub async fn channel_states_monitor(
             AND last_commit_time >= now() - interval '30 days')
             OR
             state NOT IN ('closed_cooperative', 'closed_uncooperative')"#;
+        let mainnet_known_sql = "SELECT channel_outpoint FROM channel_states";
+        let testnet_known_sql = "SELECT channel_outpoint FROM channel_states_testnet";
 
         let mainnet_states = sqlx::query(mainnet_sql)
             .fetch_all(pool)
@@ -637,8 +639,33 @@ pub async fn channel_states_monitor(
                 }
             })
             .collect::<Vec<_>>();
+        let mainnet_known = sqlx::query(mainnet_known_sql)
+            .fetch_all(pool)
+            .await
+            .expect("failed to fetch mainnet known channel outpoints")
+            .iter()
+            .map(|row| {
+                (
+                    Network::Mainnet,
+                    decode_channel_outpoint(&row.get::<String, _>("channel_outpoint")),
+                )
+            })
+            .collect::<Vec<_>>();
+        let testnet_known = sqlx::query(testnet_known_sql)
+            .fetch_all(pool)
+            .await
+            .expect("failed to fetch testnet known channel outpoints")
+            .iter()
+            .map(|row| {
+                (
+                    Network::Testnet,
+                    decode_channel_outpoint(&row.get::<String, _>("channel_outpoint")),
+                )
+            })
+            .collect::<Vec<_>>();
         ChannelStates {
             channels: mainnet_states.into_iter().chain(testnet_states).collect(),
+            known_channel_outpoints: mainnet_known.into_iter().chain(testnet_known).collect(),
         }
     };
 
@@ -657,18 +684,17 @@ pub async fn channel_states_monitor(
                 CHANNEL_MONITOR_HEARTBEAT.store(Utc::now().timestamp() as u64, std::sync::atomic::Ordering::Release);
             }
             Some((net, new)) = recv.recv() => {
-                let new = new.into_iter().filter_map(|op| {
-                    if channel_states.channels.contains_key(&op) {
-                        None
-                    } else {
-                        Some(op)
-                    }
-                }).collect::<Vec<_>>();
+                let new = unknown_channel_outpoints(
+                    &channel_states.known_channel_outpoints,
+                    net,
+                    new,
+                );
                 log::info!("{:?}, new channels received: {}", net, new.len());
                 if !new.is_empty() {
                     let groups = new_channels(net, new, &rpc).await;
                     for group in groups {
                         let (outpoint, state) = group.into_state();
+                        channel_states.known_channel_outpoints.insert((net, outpoint.clone()));
                         channel_states.channels.insert(outpoint, state);
                     }
                 }
@@ -1183,6 +1209,27 @@ struct ChannelState {
 
 struct ChannelStates {
     channels: HashMap<JsonBytes, ChannelState>,
+    known_channel_outpoints: HashSet<(Network, JsonBytes)>,
+}
+
+fn decode_channel_outpoint(raw_outpoint: &str) -> JsonBytes {
+    let mut buf = vec![0u8; raw_outpoint.len() / 2];
+    hex_decode(raw_outpoint.as_bytes(), &mut buf).unwrap();
+    JsonBytes::from_bytes(buf.into())
+}
+
+fn unknown_channel_outpoints(
+    known_channel_outpoints: &HashSet<(Network, JsonBytes)>,
+    net: Network,
+    outpoints: Vec<JsonBytes>,
+) -> Vec<JsonBytes> {
+    let mut seen = HashSet::new();
+    outpoints
+        .into_iter()
+        .filter(|op| {
+            !known_channel_outpoints.contains(&(net, op.clone())) && seen.insert(op.clone())
+        })
+        .collect()
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -1749,4 +1796,28 @@ pub fn multiaddr_to_socketaddr(addr: &Multiaddr) -> Option<SocketAddr> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_channel_outpoints_are_not_returned_as_new_channels() {
+        let known_outpoint = JsonBytes::from_vec(vec![1, 2, 3]);
+        let unknown_outpoint = JsonBytes::from_vec(vec![4, 5, 6]);
+        let known = HashSet::from([(Network::Testnet, known_outpoint.clone())]);
+
+        let new_channels = unknown_channel_outpoints(
+            &known,
+            Network::Testnet,
+            vec![
+                known_outpoint.clone(),
+                unknown_outpoint.clone(),
+                unknown_outpoint.clone(),
+            ],
+        );
+
+        assert_eq!(new_channels, vec![unknown_outpoint]);
+    }
 }


### PR DESCRIPTION
## Summary

- Require a matching `channel_states` row in daily statistics channel aggregation.
- Track all persisted channel outpoints separately from monitorable channel states.
- Prevent old closed channels returned by the Fiber graph from being reinserted into `channel_states_testnet`.

## Root Cause

### Daily Statistics Panic

The daily statistics query used a `LEFT JOIN` from `online_channels_hourly` to `channel_states`, but Rust decoded `r.capacity` as a required `String`. Graph channels without indexed channel state returned `NULL` capacity and caused a panic at `src/pg_write/operates.rs:281`.

### Channel State Insert Panic

`channel_states_monitor` used one in-memory map for two different meanings:

- channels that still need state monitoring
- channels already known in the database

On startup, the monitor intentionally excluded old closed channels:

```sql
(state IN ('closed_cooperative', 'closed_uncooperative')
 AND last_commit_time >= now() - interval '30 days')
OR state NOT IN ('closed_cooperative', 'closed_uncooperative')
```

If the Fiber graph still returned an old closed channel, the dashboard did not find it in the monitor map, treated it as a new channel, and attempted to insert it into `channel_states_testnet` again. The database rejected the duplicate primary key, and `ChannelGroup::state_sql(...).await.unwrap()` panicked at `src/pg_write/operates.rs:1717`.

## Evidence

### Daily Statistics Evidence

The staging logs show the daily stats query completed successfully and returned rows before the panic:

```text
rows_returned=48058
Panic occurred ... src/pg_write/operates.rs, line: 281
```

Line 281 decodes `row.get::<String, _>("capacity")`, which fails if the SQL result has `NULL` capacity.

The following staging SQL confirmed rows in the same daily stats window where graph channel data has no matching channel state:

```sql
SELECT
  count(*) AS rows_with_missing_channel_state
FROM online_channels_hourly_testnet n
LEFT JOIN channel_states_testnet r
  ON n.channel_outpoint = r.channel_outpoint
WHERE n.bucket < date_trunc('day', now())
  AND n.bucket >= now() - interval '20 days'
  AND r.channel_outpoint IS NULL;
```

Result:

```text
rows_with_missing_channel_state
--------------------------------
9
```

A distinct sample of those missing channel-state rows:

```sql
SELECT DISTINCT ON (n.channel_outpoint)
  n.bucket,
  n.channel_outpoint,
  n.capacity AS graph_asset_capacity,
  r.capacity AS state_capacity
FROM online_channels_hourly_testnet n
LEFT JOIN channel_states_testnet r
  ON n.channel_outpoint = r.channel_outpoint
WHERE n.bucket < date_trunc('day', now())
  AND n.bucket >= now() - interval '20 days'
  AND r.channel_outpoint IS NULL
ORDER BY n.channel_outpoint, n.bucket DESC
LIMIT 20;
```

Result:

```text
bucket                  | channel_outpoint                                                         | graph_asset_capacity             | state_capacity
------------------------+--------------------------------------------------------------------------+----------------------------------+---------------
2026-06-22 22:00:00+00 | 001b7fa2c1c0706d2bde37e44e05a669c9f1c9c6d430fc9ca7269494c7f010be00000000 | 00000000000000000000000005f5e100 | NULL
2026-06-22 17:00:00+00 | 44f4f45019ac350460837b928d342988386eaec840513a0b4a17506121d277a600000000 | 000000000000000000000002dd231b00 | NULL
2026-06-22 22:00:00+00 | ad40f3c0bb7328d12371f81b7a404cc1a97c0af8b992c767a2550de154260ce100000000 | 0000000000000000000000016b969d00 | NULL
```

### Channel State Insert Evidence

Postgres logs from staging showed repeated duplicate primary-key failures on the channel-state insert path:

```text
ERROR: duplicate key value violates unique constraint "channel_states_testnet_pkey"
DETAIL: Key (channel_outpoint)=(c165aa9ffd3593b79ac281c41faea7f3ad50c3632cbfd45d62ab08337a1a094c00000000) already exists.
STATEMENT: insert into channel_states_testnet (channel_outpoint, funding_args, capacity, last_tx_hash, last_block_number, udt_value, create_time, last_commit_time, last_commitment_args, state) VALUES ...
LOG: could not receive data from client: Connection reset by peer
```

The DB log archive contained 68 occurrences of:

```text
duplicate key value violates unique constraint "channel_states_testnet_pkey"
```

The staging database also confirmed old closed channels are still present in recent graph data:

```sql
SELECT count(*) AS old_closed_channels_seen_in_recent_graph
FROM (
  SELECT DISTINCT n.channel_outpoint
  FROM online_channels_hourly_testnet n
  JOIN channel_states_testnet s
    ON n.channel_outpoint = s.channel_outpoint
  WHERE n.bucket >= now() - interval '20 days'
    AND s.state IN ('closed_cooperative', 'closed_uncooperative')
    AND s.last_commit_time < now() - interval '30 days'
) t;
```

Result:

```text
old_closed_channels_seen_in_recent_graph
----------------------------------------
881
```

One duplicate key from the logs was already stored as an old closed channel, while graph data still saw it recently:

```sql
SELECT
  s.channel_outpoint,
  s.state,
  s.last_commit_time,
  max(n.bucket) AS last_seen_bucket,
  s.last_commit_time < now() - interval '30 days' AS excluded_by_monitor_startup_query
FROM channel_states_testnet s
LEFT JOIN online_channels_hourly_testnet n
  ON n.channel_outpoint = s.channel_outpoint
WHERE s.channel_outpoint = 'c165aa9ffd3593b79ac281c41faea7f3ad50c3632cbfd45d62ab08337a1a094c00000000'
GROUP BY s.channel_outpoint, s.state, s.last_commit_time;
```

Result:

```text
channel_outpoint                                                         | state              | last_commit_time           | last_seen_bucket       | excluded_by_monitor_startup_query
-------------------------------------------------------------------------+--------------------+----------------------------+------------------------+-----------------------------------
c165aa9ffd3593b79ac281c41faea7f3ad50c3632cbfd45d62ab08337a1a094c00000000 | closed_cooperative | 2026-04-06 16:16:37.146+00 | 2026-06-23 07:00:00+00 | t
```
